### PR TITLE
Fixes for Issues #2983 and #2984 and #2985

### DIFF
--- a/R/ARIMATimeSeries.R
+++ b/R/ARIMATimeSeries.R
@@ -552,15 +552,19 @@ ARIMATimeSeries <- function(jaspResults, dataset, options) {
   # save forecasts in a seperate .csv file
   # it is not possible to append forecasts to the spreadsheet
   # because that would require adding rows instead of columns
-  if (options$forecastSave != "") {
+  if (options$forecastSave != "" && ready && options$forecastLength > 0) {
     yName <- decodeColNames(options$dependent[1])
 
     .tsForecasts(fit, dataset, datasetRaw, options, jaspResults, ready)
     pred <- jaspResults[["forecastResult"]]$object
-    names(pred) <- c("t", yName, "lower80", "upper80", "lower95", "upper95")
-    utils::write.csv(pred, file = options$forecastSave, row.names = FALSE)
+
+    if (!is.null(pred)) {
+      names(pred) <- c("t", yName, "lower80", "upper80", "lower95", "upper95")
+      utils::write.csv(pred, file = options$forecastSave, row.names = FALSE)
+    }
   }
 }
+
 
 .tsCreateTableForecasts <- function(jaspResults, fit, dataset, datasetRaw, options, ready, position, dependencies) {
   if (!is.null(jaspResults[["forecastTable"]]) || !options$forecastTable) {

--- a/R/ARIMATimeSeries.R
+++ b/R/ARIMATimeSeries.R
@@ -451,7 +451,8 @@ ARIMATimeSeries <- function(jaspResults, dataset, options) {
           )
         )
       }
-      covariatesForecast <- covariates[rangeForecast]
+      # covariatesForecast <- covariates[rangeForecast]
+      covariatesForecast <- covariates[rangeForecast, ]
       xreg <- as.matrix(covariatesForecast)
     }
 

--- a/R/ARIMATimeSeries.R
+++ b/R/ARIMATimeSeries.R
@@ -451,7 +451,6 @@ ARIMATimeSeries <- function(jaspResults, dataset, options) {
           )
         )
       }
-      # covariatesForecast <- covariates[rangeForecast]
       covariatesForecast <- covariates[rangeForecast, ]
       xreg <- as.matrix(covariatesForecast)
     }

--- a/R/StationarityTimeSeries.R
+++ b/R/StationarityTimeSeries.R
@@ -89,15 +89,22 @@ StationarityTimeSeries <- function(jaspResults, dataset, options) {
   # apply detrend using linear regression and save only residuals
   if (options$detrend) {
     if (options$polynomialSpecification == "custom") {
-      transformedDataset$y <- residuals(lm(y ~ poly(as.integer(t), options$detrendPoly), data = transformedDataset))
+      completeRows <- complete.cases(transformedDataset[, c("y", "t")])
+      fit <- lm(y ~ poly(as.integer(t), options$detrendPoly), data = transformedDataset[completeRows, ])
+      residualsVec <- residuals(fit)
+      transformedDataset$y[completeRows] <- residualsVec
     }
+
     if (options$polynomialSpecification == "auto") {
+      completeRows <- complete.cases(transformedDataset[, c("y", "t")])
       .tsComputePolyResults(transformedDataset, options, jaspResults, ready)
       lmFit <- jaspResults[["polyResult"]]$object
       best <- which.min(unlist(lmFit[options$polynomialSpecificationAutoIc, ]))
-      transformedDataset$y <- unlist(lmFit["residuals", best])
+      residualsVec <- unlist(lmFit["residuals", best])
+      transformedDataset$y[completeRows] <- residualsVec
     }
   }
+
 
   # apply differencing
   if (options$difference) {


### PR DESCRIPTION
This pull request fixes three errors that were detected when testing. 

A) Wrong R indice in ARIMATimeSeries led to crash when in filtered time series forecast is selected with multiple covariates. This was supposed to count rows not variables

B) In StationarityTimeSeries, detrending based on linear regression did not work when NA in data set, because code would try to overwrite the full data set with a shorter (without NA) vector. Detrending now with complete cases and reassigned to original position keeping NAs

C) Crash when forecast is selected and unselected

Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2983
Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2984
Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2985